### PR TITLE
add cosign workflow

### DIFF
--- a/.github/workflows/cosign.yml
+++ b/.github/workflows/cosign.yml
@@ -1,0 +1,20 @@
+name: install-cosign-and-use
+on:
+  # This will trigger the workflow to run when commits are pushed to the main branch.
+  # This is easy for testing purposes, but for your final workflow use whatever event 
+  # or schedule makes sense for your project.
+   push:
+    branches: [ main ]
+
+jobs:
+  install-cosign-and-use:
+    name: Install Cosign
+    runs-on: ubuntu-latest
+    # 'id-token' needs write permission to retrieve the OIDC token, which is required for authentication.
+    permissions:
+      id-token: write
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.7.0
+      - name: Check install!
+        run: cosign version


### PR DESCRIPTION
Add cosign workflow to test cosign-python CI implementation 
In this workflow we'll demonstrate  Using gh-action-sigstore-python to sign files in the CI System

 [#](https://docs.sigstore.dev/quickstart/quickstart-ci/#using-gh-action-sigstore-python-to-sign-files-within-your-ci-system)